### PR TITLE
TA#72372 [14.0][UPD] Remove Codacy coverage from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,9 @@ jobs:
           name: Run Test
           command: docker-compose run --rm odoo run_pytest.sh
 
-      - run:
-          name: Codacy Coverage
-          command: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l python -r .log/coverage.xml
+      # - run:
+      #     name: Codacy Coverage
+      #     command: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l python -r .log/coverage.xml
 
       - store_test_results:
           path: .log


### PR DESCRIPTION
## Summary
- Comment out Codacy Coverage steps from CircleCI configuration for 14.0 branch
- This removes the Codacy coverage reporting while keeping all other CI functionality intact

## Test plan
- [x] Verify CircleCI configuration syntax is still valid
- [x] Confirm only Codacy lines are commented out  
- [x] Check that all other CI steps remain functional

🤖 Generated with [Claude Code](https://claude.ai/code)